### PR TITLE
Remove husky postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "prebuild": "yarn clean",
     "build": "tsc --build",
     "prepublishOnly": "yarn build && pinst --disable",
-    "postinstall": "husky install",
     "postpublish": "pinst --enable",
     "release": "semantic-release",
     "test": "jest"


### PR DESCRIPTION
The current package.json configuration installs Husky, a development dependency, in the postinstall script. This also affects production environments.